### PR TITLE
Quick and dirty fix to allow WriteXmlIfChanged to write xml in utf-8, co...

### DIFF
--- a/gyp/pylib/gyp/easy_xml.py
+++ b/gyp/pylib/gyp/easy_xml.py
@@ -115,6 +115,11 @@ def WriteXmlIfChanged(content, path, encoding='utf-8', pretty=False,
   xml_string = XmlToString(content, encoding, pretty)
   if win32 and os.linesep != '\r\n':
     xml_string = xml_string.replace('\n', '\r\n')
+    
+  try:
+    xml_string = xml_string.encode(encoding)
+  except Exception:
+    xml_string = unicode(xml_string, 'latin-1').encode(encoding)
 
   # Get the old content
   try:
@@ -127,11 +132,6 @@ def WriteXmlIfChanged(content, path, encoding='utf-8', pretty=False,
   # It has changed, write it
   if existing != xml_string:
     f = open(path, 'w')
-    try:
-      dec = unicode(xml_string, 'latin-1').encode('utf-8')
-      xml_string = dec
-    except Exception as inst:
-      pass
     f.write(xml_string)
     f.close()
 

--- a/gyp/pylib/gyp/easy_xml.py
+++ b/gyp/pylib/gyp/easy_xml.py
@@ -127,6 +127,11 @@ def WriteXmlIfChanged(content, path, encoding='utf-8', pretty=False,
   # It has changed, write it
   if existing != xml_string:
     f = open(path, 'w')
+    try:
+      dec = unicode(xml_string, 'latin-1').encode('utf-8')
+      xml_string = dec
+    except Exception as inst:
+      pass
     f.write(xml_string)
     f.close()
 


### PR DESCRIPTION
This is a quick and dirty fix to allow node-gyp to generate the vcxproj when the are latin-1 characters in the paths.

I'm not a python programmer, this just solved the problem I had with latin-1 characters..

WriteXmlIfChanged was not actually writing in utf-8, but in ascii. Converting directly to utf-8 would fail if unicode(string, native_enconding) is not called first.