### PR TITLE
Show better error message in case of bad network settings

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -214,6 +214,11 @@ function install (gyp, argv, callback) {
 
       // something went wrong downloading the tarball?
       req.on('error', function (err) {
+        if (err.code === 'ENOTFOUND') {
+          return cb(new Error('This is most likely not a problem with node-gyp or the package itself and\n' +
+            'is related to network connectivity. In most cases you are behind a proxy or have bad \n' +
+            'network settings.'))
+        }
         badDownload = true
         cb(err)
       })


### PR DESCRIPTION
Instead of just showing Error: getaddrinfo ENOTFOUND
this will show an error message to the user

Turns out the message is quite irritating to users, e.g:
https://github.com/voodootikigod/node-serialport/issues/288