### PR TITLE
fix python searching and executing

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -43,6 +43,7 @@ function configure (gyp, argv, callback) {
         }
       } else {
         log.verbose('`which` succeeded', python, execPath)
+        if ( python === 'python' ) { python = execPath }
         checkPythonVersion()
       }
     })


### PR DESCRIPTION
node-gyp can't find python if used some redirecting stuff (like way that uses npm for all global modules).

For example my python.bat (python.bat is in PATH)
```'
@E:\TOOLS\PYTHON27\python.exe %*
```
node-gyp correctly search python.bat but can't execute him:
```
gyp info it worked if it ends with ok
gyp verb cli [ 'node',
gyp verb cli   'D:\\Home\\Application Data\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js',
gyp verb cli   'configure',
gyp verb cli   '--verbose' ]
gyp info using node-gyp@0.12.2
gyp info using node@0.10.23 | win32 | ia32
gyp verb command configure []
gyp verb check python checking for Python executable "python" in the PATH
gyp verb `which` succeeded python C:\BATCH\python.BAT
gyp ERR! configure error
gyp ERR! stack Error: spawn ENOENT
gyp ERR! stack     at errnoException (child_process.js:980:11)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:771:34)
gyp ERR! System Windows_NT 5.1.2600
gyp ERR! command "node" "D:\\Home\\Application Data\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js"
```
After this patch all worked well.
