### PR TITLE
Import local gyp.py, then fallback to system

### DIFF
--- a/gyp/gyp_main.py
+++ b/gyp/gyp_main.py
@@ -8,10 +8,10 @@ import sys
 
 # TODO(mark): sys.path manipulation is some temporary testing stuff.
 try:
+  import os.path
+  sys.path = [ os.path.join(os.path.dirname(sys.argv[0]), 'pylib') ] + sys.path
   import gyp
 except ImportError, e:
-  import os.path
-  sys.path.append(os.path.join(os.path.dirname(sys.argv[0]), 'pylib'))
   import gyp
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some hosts have an old gyp version, which causes an ImportError.
It is better to import newer gyp.py first, then fallback to system-wide version.