### PR TITLE
Adds support for custom GYP include

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -9,6 +9,7 @@ var fs = require('graceful-fs')
   , glob = require('glob')
   , log = require('npmlog')
   , osenv = require('osenv')
+  , process = require('process')
   , which = require('which')
   , semver = require('semver')
   , mkdirp = require('mkdirp')
@@ -320,6 +321,11 @@ function configure (gyp, argv, callback) {
 
     // tell make to write its output into the same dir
     argv.push('-Goutput_dir=.')
+    
+    // allow user to specify additional gyp file so they can override system specific settings
+    if ('NODE_GYP_ADDITIONAL_CONFIG' in process.env) {
+        argv.unshift('-I', process.env.NODE_GYP_ADDITIONAL_CONFIG)
+    }
 
     // enforce use of the "binding.gyp" file
     argv.unshift('binding.gyp')

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "rimraf": "2",
     "semver": "~2.2.1",
     "tar": "0",
-    "which": "1"
+    "which": "1",
+    "process": "0"
   },
   "engines": {
     "node": ">= 0.8.0"


### PR DESCRIPTION
When developers have libraries in non-standard locations (or don't wish
to dump them into System32 on Windows), they need to run "node-gyp
configure", edit the generated files to add include paths, and then run
"node-gyp install"

This is doubly painful when you wanted to "npm install" something, but
it depends on a library being in a default path on your system.

I've added the ability for users to include an additional ".gyp" file in
all node-gyp builds by setting an environment variable
(NODE_GYP_ADDITIONAL_CONFIG), which they can use to configure
include/library paths.  No longer must I manually install packages or
dump files into global include directories.