### PR TITLE
Checking custom npm proxy before system defined proxy

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -129,9 +129,10 @@ function install (gyp, argv, callback) {
 
     // basic support for a proxy server
     var proxyUrl = gyp.opts.proxy
+                || process.env.npm_config_proxy
                 || process.env.http_proxy
                 || process.env.HTTP_PROXY
-                || process.env.npm_config_proxy
+
     if (proxyUrl) {
       if (/^https?:\/\//i.test(proxyUrl)) {
         log.verbose('download', 'using proxy url: "%s"', proxyUrl)


### PR DESCRIPTION
Hi,

I'm encountering an issue with node-gyp as I need to have my Windows default proxy environment vars without the http:// prefix. Since node-gyp checks this prefix to validate the proxy url, I can't use it in an automated process (ie. github atom package install). 
The easiest solution I've found is to check the npm_config_proxy before the standard proxy vars. It works in my case but to me it also seems more logical as using it to override default proxy settings in node related operations is for me a common usage.