### PR TITLE
Include node_root_dir in include path

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -3,6 +3,7 @@
     'type': 'loadable_module',
     'product_prefix': '',
     'include_dirs': [
+      '<(node_root_dir)',
       '<(node_root_dir)/src',
       '<(node_root_dir)/deps/uv/include',
       '<(node_root_dir)/deps/v8/include'


### PR DESCRIPTION
Currently the `--nodedir` option assumes the path given contains `src/` and `deps/`, but bundled with each release of node is the same files in a somewhat flattened directory structure at `$PREFIX/include/node/`.

This is a quick hack to allow `--nodedir=$PREFIX/include/node` work, which lets node-gyp build against the headers bundled with the version of node being run, even if it isn't an official release.

It would work best if either node releases or the bundled version of npm pre-configured nodedir to point at the bundled headers.