### PR TITLE
configure: don't clobber existing $PYTHONPATH

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -328,7 +328,9 @@ function configure (gyp, argv, callback) {
     argv.unshift(gyp_script)
 
     // make sure python uses files that came with this particular node package
-    process.env.PYTHONPATH = path.resolve(__dirname, '..', 'gyp', 'pylib')
+    var pypath = process.env.PYTHONPATH ? [process.env.PYTHONPATH] : []
+    pypath.unshift(path.resolve(__dirname, '..', 'gyp', 'pylib'))
+    process.env.PYTHONPATH = pypath.join(process.platform === "win32" ? ";" : ":");
 
     var cp = gyp.spawn(python, argv)
     cp.on('exit', onCpExit)


### PR DESCRIPTION
My `node` executable happens to be a wrapper created by 0install, implemented in python. It relies on some library code being available on `$PYTHONPATH`. Which means it can't run when `npm-gyp` overwrites `$PYTHONPATH` to include _only_ the bundled `gyp/pylib` dir.

This commit achieves the same effect as the existing code (giving the bundled `gyp` module priority), but without clobbering an existing `$PYTHONPATH` value.