### PR TITLE
Fixed #526. Check for python2 executable by default, fallback to python

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -22,20 +22,23 @@ exports.usage = 'Generates ' + (win ? 'MSVC project files' : 'a Makefile') + ' f
 
 function configure (gyp, argv, callback) {
 
-  var python = gyp.opts.python || process.env.PYTHON || 'python'
+  var python = gyp.opts.python || process.env.PYTHON || 'python2'
     , buildDir = path.resolve('build')
     , configNames = [ 'config.gypi', 'common.gypi' ]
     , configs = []
     , nodeDir
 
-  checkPython()
+  checkPython(python)
 
   // Check if Python is in the $PATH
-  function checkPython () {
+  function checkPython (pythonCmd) {
     log.verbose('check python', 'checking for Python executable "%s" in the PATH', python)
     which(python, function (err, execPath) {
       if (err) {
         log.verbose('`which` failed', python, err)
+        if (python === 'python2') {
+          return checkPython('python');
+        }
         if (win) {
           guessPython()
         } else {


### PR DESCRIPTION
Fixes #526 