### PR TITLE
rebuild: forward arguments to configure phase

### DIFF
--- a/lib/rebuild.js
+++ b/lib/rebuild.js
@@ -9,7 +9,7 @@ function rebuild (gyp, argv, callback) {
 
   gyp.todo.push(
       { name: 'clean', args: [] }
-    , { name: 'configure', args: [] }
+    , { name: 'configure', args: argv }
     , { name: 'build', args: [] }
   )
   process.nextTick(callback)


### PR DESCRIPTION
The rebuild command currently ignores additional command line arguments. I think it makes sense to pass these arguments to the configure phase:

````
> node-gyp rebuild -- -I some.gypi
````