### PR TITLE
Set '-undefined dynamic_lookup' in Xcode projects

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -25,7 +25,8 @@
         'defines': [ '_DARWIN_USE_64_BIT_INODE=1' ],
         'libraries': [ '-undefined dynamic_lookup' ],
         'xcode_settings': {
-          'DYLIB_INSTALL_NAME_BASE': '@rpath'
+          'DYLIB_INSTALL_NAME_BASE': '@rpath',
+          'OTHER_LDFLAGS' : [ '-undefined dynamic_lookup' ]
         },
       }],
       [ 'OS=="win"', {


### PR DESCRIPTION
The current solution to set the flag using the `libraries` field does not work on current Xcode:

![screen shot 2014-11-14 at 15 34 09](https://cloud.githubusercontent.com/assets/137545/5047534/bfd5f6b0-6c16-11e4-9a67-f603474c172a.png)

Here is a patch. I left the old hack in place because it _might_ have worked with older Xcode/gyp combinations. 