### PR TITLE
Add target name preprocessor define

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -7,6 +7,7 @@
       '<(node_root_dir)/deps/uv/include',
       '<(node_root_dir)/deps/v8/include'
     ],
+    'defines': ['NODE_GYP_MODULE_NAME=>(_target_name)'],
 
     'target_conditions': [
       ['_type=="loadable_module"', {


### PR DESCRIPTION
Adds the name of the current target as a preprocessor define. Uses the automatic variable `_target_name` in combination with late variable expansion.

It originates in joyent/node#8802 but has other applications, too. Think logging. It's a little service to downstream add-ons to keep things DRY.