### PR TITLE
Fix encoding errors

### DIFF
--- a/gyp/pylib/gyp/easy_xml.py
+++ b/gyp/pylib/gyp/easy_xml.py
@@ -115,6 +115,9 @@ def WriteXmlIfChanged(content, path, encoding='utf-8', pretty=False,
   xml_string = XmlToString(content, encoding, pretty)
   if win32 and os.linesep != '\r\n':
     xml_string = xml_string.replace('\n', '\r\n')
+  
+  # Fix encoding
+  xml_string = unicode(xml_string, 'latin-1').encode(encoding)
 
   # Get the old content
   try:


### PR DESCRIPTION
On Windows, when gyp reads and writes vcxproj files, it messes up with the encodings, because the generated XML files are stored as Latin-1 files instead of UTF-8.

It can become problematic since project files often contain paths, and paths can contain accented characters that are handled differently between Latin-1 and UTF-8. This PR addresses the issue by converting encoding to UTF-8 right before the file is saved.

This problem is not new, it has already been reported in issues #297, #404, #476 atom/atom#1937,  ZECTBynmo/node-core-audio#27, and many others. Pull request #366 was sent a year ago as an attempt to fix the problem, but wasn't taken into consideration. Two years after the initial report, this important issue remains unsolved.