### PR TITLE
Allow for 1.x npmlog

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "minimatch": "1",
     "mkdirp": "^0.5.0",
     "nopt": "2 || 3",
-    "npmlog": "0",
+    "npmlog": "0 || 1",
     "osenv": "0",
     "request": "2",
     "rimraf": "2",


### PR DESCRIPTION
Which doesn't break the interface and is only going to 1.x to get
normal semver semantics going forward.
