### PR TITLE
Restore compatibility with Node.js v0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "minimatch": "1",
     "mkdirp": "^0.5.0",
     "nopt": "2 || 3",
-    "npmlog": "0 || 1",
+    "npmlog": "0",
     "osenv": "0",
     "request": "2",
     "rimraf": "2",


### PR DESCRIPTION
This reverts “[Allow for 1.x npmlog](https://github.com/TooTallNate/node-gyp/commit/a9688cdcf36ee12e7004a5feb0d8fc3e7be8ed52)” because are-we-there-yet, one of npmlog’s dependencies, [doesn’t work under Node.js v0.8](https://github.com/iarna/are-we-there-yet/issues/1).

[This Travis CI build](https://travis-ci.org/SonicHedgehog/node-gyp/jobs/54464558), running Node.js v0.8.28 and node-gyp v1.0.3, shows the error that occurs (the same as in #590). Reverting the above commit [fixes the issue](https://travis-ci.org/SonicHedgehog/node-gyp/jobs/54464710).

Fixes #590.