### PR TITLE
Avoid downloading shasums if using tarPath

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -277,9 +277,12 @@ function install (gyp, argv, callback) {
         var installVersionPath = path.resolve(devDir, 'installVersion')
         fs.writeFile(installVersionPath, gyp.package.installVersion + '\n', deref)
 
-        // download SHASUMS.txt
-        async++
-        downloadShasums(deref)
+        // Only download SHASUMS.txt if not using tarPath override
+        if (!tarPath) {
+          // download SHASUMS.txt
+          async++
+          downloadShasums(deref)
+        }
 
         if (async === 0) {
           // no async tasks required


### PR DESCRIPTION
If using a manually provided `tarPath` the [content shasums](https://github.com/TooTallNate/node-gyp/blob/master/lib/install.js#L250-L254) aren't [actually computed](https://github.com/TooTallNate/node-gyp/blob/master/lib/install.js#L225) and downloading the remote shasums is a bit of a waste.

This avoids the call, and makes it so you can provide a local tarball with the necessary source files without any external network calls.