### PR TITLE
win: allow node.exe/iojs.exe to be renamed

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -1,7 +1,9 @@
 {
   'target_defaults': {
     'type': 'loadable_module',
+    'win_delay_load_hook': 'false',
     'product_prefix': '',
+
     'include_dirs': [
       '<(node_root_dir)/src',
       '<(node_root_dir)/deps/uv/include',
@@ -13,10 +15,33 @@
         'product_extension': 'node',
         'defines': [ 'BUILDING_NODE_EXTENSION' ],
       }],
+
       ['_type=="static_library"', {
         # set to `1` to *disable* the -T thin archive 'ld' flag.
         # older linkers don't support this flag.
         'standalone_static_library': '<(standalone_static_library)'
+      }],
+
+      ['_win_delay_load_hook=="true"', {
+        # If the addon specifies `'win_delay_load_hook': 'true'` in its
+        # binding.gyp, link a delay-load hook into the DLL. This hook ensures
+        # that the addon will work regardless of whether the node/iojs binary
+        # is named node.exe, iojs.exe, or something else.
+        'conditions': [
+          [ 'OS=="win"', {
+            'sources': [
+              'src/win_delay_load_hook.c',
+            ],
+            'msvs_settings': {
+              'VCLinkerTool': {
+                'DelayLoadDLLs': [ 'iojs.exe', 'node.exe' ],
+                # Don't print a linker warning when no imports from either .exe
+                # are used.
+                'AdditionalOptions': [ '/ignore:4199' ],
+              },
+            },
+          }],
+        ],
       }],
     ],
 

--- a/src/win_delay_load_hook.c
+++ b/src/win_delay_load_hook.c
@@ -1,0 +1,32 @@
+/*
+ * When this file is linked to a DLL, it sets up a delay-load hook that
+ * intervenes when the DLL is trying to load 'node.exe' or 'iojs.exe'
+ * dynamically. Instead of trying to locate the .exe file it'll just return
+ * a handle to the process image.
+ *
+ * This allows compiled addons to work when node.exe or iojs.exe is renamed.
+ */
+
+#ifdef _MSC_VER
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <delayimp.h>
+#include <string.h>
+
+static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+  if (event != dliNotePreLoadLibrary)
+    return NULL;
+
+  if (_stricmp(info->szDll, "iojs.exe") != 0 &&
+      _stricmp(info->szDll, "node.exe") != 0)
+    return NULL;
+
+  HMODULE m = GetModuleHandle(NULL);
+  return (FARPROC) m;
+}
+
+PfnDliHook __pfnDliNotifyHook2 = load_exe_hook;
+
+#endif


### PR DESCRIPTION
On Windows, when node or io.js attempts to dynamically load a compiled
addon, the compiled addon tries to load node.exe or iojs.exe again -
depending on which import library the module used when it was linked.
This makes it impossible to rename node.exe or iojs.exe, because when
that happens the module can't find its dependencies.

With this patch, a delay-load hook is added to all modules that are
compiled with node-gyp. The delay-load hook ensures that whenever a
module tries to load imports from node.exe/iojs.exe, it'll just refer
back to the process image, thus making it possible to rename the
iojs/node binary.

Bug: iojs/io.js#751
Bug: iojs/io.js#965
Downstream PR: iojs/io.js#1251