### PR TITLE
Only add "-undefined dynamic_lookup" to loadable_module targets

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -14,6 +14,9 @@
       ['_type=="loadable_module"', {
         'product_extension': 'node',
         'defines': [ 'BUILDING_NODE_EXTENSION' ],
+        'xcode_settings': {
+          'OTHER_LDFLAGS': [ '-undefined dynamic_lookup' ],
+        },
       }],
 
       ['_type=="static_library"', {
@@ -48,7 +51,6 @@
     'conditions': [
       [ 'OS=="mac"', {
         'defines': [ '_DARWIN_USE_64_BIT_INODE=1' ],
-        'libraries': [ '-undefined dynamic_lookup' ],
         'xcode_settings': {
           'DYLIB_INSTALL_NAME_BASE': '@rpath'
         },


### PR DESCRIPTION
Adding `-undefined dynamic_lookup` to all targets makes it impossible to create Xcode projects with node-gyp for gyp files that also include `none` targets. Since `none` targets don't have a framework phase, gyp errors when trying to add the link flag.

In addition, `-undefined dynamic_lookup` should be added as a linker flag, not a link library, so it's now passed in the `OTHER_LDFLAGS` setting.

This also fixes #536.