### PR TITLE
move HMODULE m declaration to top

### DIFF
--- a/src/win_delay_load_hook.c
+++ b/src/win_delay_load_hook.c
@@ -16,6 +16,7 @@
 #include <string.h>
 
 static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+  HMODULE m;
   if (event != dliNotePreLoadLibrary)
     return NULL;
 
@@ -23,7 +24,7 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
       _stricmp(info->szDll, "node.exe") != 0)
     return NULL;
 
-  HMODULE m = GetModuleHandle(NULL);
+  m = GetModuleHandle(NULL);
   return (FARPROC) m;
 }
 


### PR DESCRIPTION
The declaration of the m variable not on top causes the build to fail on VS2010(C89), Window 7 x64. 
Providing solution based on [stackoverflow answer](http://stackoverflow.com/questions/9903582/error-c2275-illegal-use-of-this-type-as-an-expression).