### PR TITLE
Setting NODE_GYP_DIR for addon.gypi to setting absolute path for src/…

### DIFF
--- a/addon.gypi
+++ b/addon.gypi
@@ -40,7 +40,7 @@
         'conditions': [
           [ 'OS=="win"', {
             'sources': [
-              'src/win_delay_load_hook.c',
+              '<(node_gyp_dir)/src/win_delay_load_hook.c',
             ],
             'msvs_settings': {
               'VCLinkerTool': {

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -316,12 +316,14 @@ function configure (gyp, argv, callback) {
       // Windows expects an absolute path
       output_dir = buildDir
     }
+    var nodeGypDir = path.resolve(__dirname, '..')
 
     argv.push('-I', addon_gypi)
     argv.push('-I', common_gypi)
     argv.push('-Dlibrary=shared_library')
     argv.push('-Dvisibility=default')
     argv.push('-Dnode_root_dir=' + nodeDir)
+    argv.push('-Dnode_gyp_dir=' + nodeGypDir)
     argv.push('-Dmodule_root_dir=' + process.cwd())
     argv.push('--depth=.')
     argv.push('--no-parallel')


### PR DESCRIPTION
…win_delay_load_hook.c,

and fixes of the long relative path issue on Win32.
Fixes of #636