### PR TITLE
allow semver@5

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "path-array": "^1.0.0",
     "request": "2",
     "rimraf": "2",
-    "semver": "2.x || 3.x || 4",
+    "semver": "2.x || 3.x || 4 || 5",
     "tar": "^1.0.0",
     "which": "1"
   },


### PR DESCRIPTION
@isaacs merged a PR that removed the built artifacts for browsers, which is a breaking version, so everything using semver needs to be updated to allow the new major version. It's a low-risk change, because there are no other changes to the package.