### PR TITLE
Update Install.js, add iojs support

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -21,6 +21,7 @@ var fs = require('graceful-fs')
   , minimatch = require('minimatch')
   , mkdir = require('mkdirp')
   , win = process.platform == 'win32'
+  , isIojs = ((process.release || {}) || {}).name === 'io.js'
 
 function install (gyp, argv, callback) {
 
@@ -39,7 +40,8 @@ function install (gyp, argv, callback) {
     }
   }
 
-  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://nodejs.org/dist'
+  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl
+             || (isIojs ? 'https://iojs.org/dist' : 'https://nodejs.org/dist')
 
 
   // Determine which node dev files version we are installing
@@ -185,11 +187,17 @@ function install (gyp, argv, callback) {
 
       // now download the node tarball
       var tarPath = gyp.opts['tarball']
-      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/node-v' + version + '.tar.gz'
+      var tarballUrl
         , badDownload = false
         , extractCount = 0
         , gunzip = zlib.createGunzip()
         , extracter = tar.Extract({ path: devDir, strip: 1, filter: isValid })
+
+      if (tarPath) {
+        tarballUrl = tarPath
+      } else {
+        tarballUrl = distUrl + '/v' + version + (isIojs ? '/iojs' : '/node') + '-v' + version + '.tar.gz'
+      }
 
       var contentShasums = {}
       var expectShasums = {}


### PR DESCRIPTION
This PR is much like https://github.com/TooTallNate/node-gyp/pull/669, but this one really works.

Fixes
>  gyp ERR! stack Error: 404 response downloading https://nodejs.org/dist/v3.0.0/node-v3.0.0.tar.gz

